### PR TITLE
Cut down on heap allocations when reading and writing shapefiles.

### DIFF
--- a/NetTopologySuite.IO.GeoTools/BigEndianBinaryReader.cs
+++ b/NetTopologySuite.IO.GeoTools/BigEndianBinaryReader.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Diagnostics;
 using System.IO;
 using System.Text;
 
@@ -34,31 +32,13 @@ namespace NetTopologySuite.IO
         /// from the current stream and advances the current position of the stream by four bytes.
         /// </summary>
         /// <returns></returns>
-        public int ReadInt32BE()
-        {
-            // big endian
-            byte[] byteArray = new byte[4];
-            int iBytesRead = Read(byteArray, 0, 4);
-            Debug.Assert(iBytesRead == 4);
-
-            Array.Reverse(byteArray);
-            return BitConverter.ToInt32(byteArray, 0);
-        }
+        public int ReadInt32BE() => BitTweaks.ReverseByteOrder(this.ReadInt32());
 
         /// <summary>
         /// Reads a 8-byte signed double using the big-endian layout
         /// from the current stream and advances the current position of the stream by eight bytes.
         /// </summary>
         /// <returns></returns>
-        public double ReadDoubleBE()
-        {
-            // big endian
-            byte[] byteArray = new byte[8];
-            int iBytesRead = Read(byteArray, 0, 8);
-            Debug.Assert(iBytesRead == 8);
-
-            Array.Reverse(byteArray);
-            return BitConverter.ToDouble(byteArray, 0);
-        }
+        public double ReadDoubleBE() => BitTweaks.ReverseByteOrder(this.ReadDouble());
     }
 }

--- a/NetTopologySuite.IO.GeoTools/BigEndianBinaryReader.cs
+++ b/NetTopologySuite.IO.GeoTools/BigEndianBinaryReader.cs
@@ -5,51 +5,51 @@ using System.Text;
 
 namespace NetTopologySuite.IO
 {
-	/// <summary>
-    /// Extends the <see cref="System.IO.BinaryReader" /> class to allow reading of integers and doubles 
+    /// <summary>
+    /// Extends the <see cref="System.IO.BinaryReader" /> class to allow reading of integers and doubles
     /// in the Big Endian format.
-	/// </summary>
-	/// <remarks>
-	/// The BinaryReader uses Little Endian format when reading binary streams.
-	/// </remarks>
-	public class BigEndianBinaryReader : BinaryReader
-	{		
-		/// <summary>
-		/// Initializes a new instance of the BigEndianBinaryReader class 
+    /// </summary>
+    /// <remarks>
+    /// The BinaryReader uses Little Endian format when reading binary streams.
+    /// </remarks>
+    public class BigEndianBinaryReader : BinaryReader
+    {
+        /// <summary>
+        /// Initializes a new instance of the BigEndianBinaryReader class
         /// based on the supplied stream and using UTF8Encoding.
-		/// </summary>
-		/// <param name="stream"></param>
-		public BigEndianBinaryReader(Stream stream)  : base(stream) { }
+        /// </summary>
+        /// <param name="stream"></param>
+        public BigEndianBinaryReader(Stream stream)  : base(stream) { }
 
-		/// <summary>
-		/// Initializes a new instance of the BigEndianBinaryReader class 
+        /// <summary>
+        /// Initializes a new instance of the BigEndianBinaryReader class
         /// based on the supplied stream and a specific character encoding.
-		/// </summary>
-		/// <param name="input"></param>
-		/// <param name="encoding"></param>
-		public BigEndianBinaryReader(Stream input, Encoding encoding) : base(input, encoding) { }		
-	
-		/// <summary>
-		/// Reads a 4-byte signed integer using the big-endian layout 
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="encoding"></param>
+        public BigEndianBinaryReader(Stream input, Encoding encoding) : base(input, encoding) { }
+
+        /// <summary>
+        /// Reads a 4-byte signed integer using the big-endian layout
         /// from the current stream and advances the current position of the stream by four bytes.
-		/// </summary>
-		/// <returns></returns>
-		public int ReadInt32BE()
-		{
-			// big endian
-			byte[] byteArray = new byte[4];
-			int iBytesRead = Read(byteArray, 0, 4);
-			Debug.Assert(iBytesRead == 4);
+        /// </summary>
+        /// <returns></returns>
+        public int ReadInt32BE()
+        {
+            // big endian
+            byte[] byteArray = new byte[4];
+            int iBytesRead = Read(byteArray, 0, 4);
+            Debug.Assert(iBytesRead == 4);
 
             Array.Reverse(byteArray);
             return BitConverter.ToInt32(byteArray, 0);
-		}
+        }
 
         /// <summary>
-        /// Reads a 8-byte signed double using the big-endian layout 
+        /// Reads a 8-byte signed double using the big-endian layout
         /// from the current stream and advances the current position of the stream by eight bytes.
         /// </summary>
-        /// <returns></returns>        
+        /// <returns></returns>
         public double ReadDoubleBE()
         {
             // big endian

--- a/NetTopologySuite.IO.GeoTools/BigEndianBinaryWriter.cs
+++ b/NetTopologySuite.IO.GeoTools/BigEndianBinaryWriter.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Diagnostics;
 using System.IO;
 using System.Text;
 
@@ -36,27 +34,13 @@ namespace NetTopologySuite.IO
         /// and advances the current position of the stream by two bytes.
         /// </summary>
         /// <param name="value">The four-byte signed integer to write.</param>
-        public void WriteIntBE(int value)
-        {
-            byte[] bytes = BitConverter.GetBytes(value);
-            Debug.Assert(bytes.Length == 4);
-
-            Array.Reverse(bytes, 0, 4);
-            Write(bytes);
-        }
+        public void WriteIntBE(int value) => this.Write(BitTweaks.ReverseByteOrder(value));
 
         /// <summary>
         /// Reads a 8-byte signed integer using the big-endian layout from the current stream
         /// and advances the current position of the stream by two bytes.
         /// </summary>
         /// <param name="value">The four-byte signed integer to write.</param>
-        public void WriteDoubleBE(double value)
-        {
-            byte[] bytes = BitConverter.GetBytes(value);
-            Debug.Assert(bytes.Length == 8);
-
-            Array.Reverse(bytes, 0, 8);
-            Write(bytes);
-        }
+        public void WriteDoubleBE(double value) => this.Write(BitTweaks.ReverseByteOrder(value));
     }
 }

--- a/NetTopologySuite.IO.GeoTools/BigEndianBinaryWriter.cs
+++ b/NetTopologySuite.IO.GeoTools/BigEndianBinaryWriter.cs
@@ -5,48 +5,48 @@ using System.Text;
 
 namespace NetTopologySuite.IO
 {
-	/// <summary>
-    /// Extends the <see cref="BinaryWriter" /> class to allow the writing of integers 
+    /// <summary>
+    /// Extends the <see cref="BinaryWriter" /> class to allow the writing of integers
     /// and double values in the Big Endian format.
-	/// </summary>
-	public class BigEndianBinaryWriter : BinaryWriter
-	{		
-		/// <summary>
-		/// Initializes a new instance of the BigEndianBinaryWriter class.
-		/// </summary>
-		public BigEndianBinaryWriter() : base() { }
+    /// </summary>
+    public class BigEndianBinaryWriter : BinaryWriter
+    {
+        /// <summary>
+        /// Initializes a new instance of the BigEndianBinaryWriter class.
+        /// </summary>
+        public BigEndianBinaryWriter() : base() { }
 
-		/// <summary>
-		/// Initializes a new instance of the BigEndianBinaryWriter class 
+        /// <summary>
+        /// Initializes a new instance of the BigEndianBinaryWriter class
         /// based on the supplied stream and using UTF-8 as the encoding for strings.
-		/// </summary>
-		/// <param name="output">The supplied stream.</param>
-		public BigEndianBinaryWriter(Stream output) : base(output) { }
+        /// </summary>
+        /// <param name="output">The supplied stream.</param>
+        public BigEndianBinaryWriter(Stream output) : base(output) { }
 
-		/// <summary>
-		/// Initializes a new instance of the BigEndianBinaryWriter class 
+        /// <summary>
+        /// Initializes a new instance of the BigEndianBinaryWriter class
         /// based on the supplied stream and a specific character encoding.
-		/// </summary>
-		/// <param name="output">The supplied stream.</param>
-		/// <param name="encoding">The character encoding.</param>
-		public BigEndianBinaryWriter(Stream output, Encoding encoding): base(output,encoding) { }
+        /// </summary>
+        /// <param name="output">The supplied stream.</param>
+        /// <param name="encoding">The character encoding.</param>
+        public BigEndianBinaryWriter(Stream output, Encoding encoding): base(output, encoding) { }
 
-		/// <summary>
-		/// Reads a 4-byte signed integer using the big-endian layout from the current stream 
+        /// <summary>
+        /// Reads a 4-byte signed integer using the big-endian layout from the current stream
         /// and advances the current position of the stream by two bytes.
-		/// </summary>
+        /// </summary>
         /// <param name="value">The four-byte signed integer to write.</param>
-		public void WriteIntBE(int value)
-		{
+        public void WriteIntBE(int value)
+        {
             byte[] bytes = BitConverter.GetBytes(value);
             Debug.Assert(bytes.Length == 4);
 
             Array.Reverse(bytes, 0, 4);
-            Write(bytes);				
-		}
+            Write(bytes);
+        }
 
         /// <summary>
-        /// Reads a 8-byte signed integer using the big-endian layout from the current stream 
+        /// Reads a 8-byte signed integer using the big-endian layout from the current stream
         /// and advances the current position of the stream by two bytes.
         /// </summary>
         /// <param name="value">The four-byte signed integer to write.</param>
@@ -58,5 +58,5 @@ namespace NetTopologySuite.IO
             Array.Reverse(bytes, 0, 8);
             Write(bytes);
         }
-	}
+    }
 }

--- a/NetTopologySuite.IO.GeoTools/BitTweaks.cs
+++ b/NetTopologySuite.IO.GeoTools/BitTweaks.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace NetTopologySuite.IO
+{
+    internal static class BitTweaks
+    {
+        internal static int ReverseByteOrder(int value) => unchecked((int)ReverseByteOrder((uint)value));
+
+        internal static long ReverseByteOrder(long value) => unchecked((long)ReverseByteOrder((ulong)value));
+
+        internal static double ReverseByteOrder(double value)
+        {
+            long bits = BitConverter.DoubleToInt64Bits(value);
+            bits = ReverseByteOrder(bits);
+            return BitConverter.Int64BitsToDouble(bits);
+        }
+
+        internal static uint ReverseByteOrder(uint value) => (value & 0x000000FF) << 24 |
+                                                             (value & 0x0000FF00) << 8 |
+                                                             (value & 0x00FF0000) >> 8 |
+                                                             (value & 0xFF000000) >> 24;
+
+        internal static ulong ReverseByteOrder(ulong value) => (value & 0x00000000000000FF) << 56 |
+                                                               (value & 0x000000000000FF00) << 40 |
+                                                               (value & 0x0000000000FF0000) << 24 |
+                                                               (value & 0x00000000FF000000) << 8 |
+                                                               (value & 0x000000FF00000000) >> 8 |
+                                                               (value & 0x0000FF0000000000) >> 24 |
+                                                               (value & 0x00FF000000000000) >> 40 |
+                                                               (value & 0xFF00000000000000) >> 56;
+    }
+}


### PR DESCRIPTION
This is pretty much exactly what I did in NetTopologySuite/NetTopologySuite@c6d2ccd.