### PR TITLE
Allow GetHeader to receive (optional) encoding

### DIFF
--- a/NetTopologySuite.IO.GeoTools/ShapefileDataWriter.cs
+++ b/NetTopologySuite.IO.GeoTools/ShapefileDataWriter.cs
@@ -20,8 +20,7 @@ namespace NetTopologySuite.IO
         /// Gets the stub header.
         /// </summary>
         /// <param name="feature">The feature.</param>
-        /// <param name="count">The count.</param>
-        /// <param name="encoding">The encoding.</param>            
+        /// <param name="count">The count.</param>         
         /// <returns></returns>
         public static DbaseFileHeader GetHeader(IFeature feature, int count)
         {

--- a/NetTopologySuite.IO.GeoTools/ShapefileDataWriter.cs
+++ b/NetTopologySuite.IO.GeoTools/ShapefileDataWriter.cs
@@ -22,11 +22,11 @@ namespace NetTopologySuite.IO
         /// <param name="feature">The feature.</param>
         /// <param name="count">The count.</param>
         /// <returns></returns>
-        public static DbaseFileHeader GetHeader(IFeature feature, int count)
+        public static DbaseFileHeader GetHeader(IFeature feature, int count, Encoding encoding = null)
         {
             var attribs = feature.Attributes;
             string[] names = attribs.GetNames();
-            var header = new DbaseFileHeader();
+            var header = new DbaseFileHeader(encoding);
             header.NumRecords = count;
             foreach (string name in names)
             {

--- a/NetTopologySuite.IO.GeoTools/ShapefileDataWriter.cs
+++ b/NetTopologySuite.IO.GeoTools/ShapefileDataWriter.cs
@@ -21,8 +21,21 @@ namespace NetTopologySuite.IO
         /// </summary>
         /// <param name="feature">The feature.</param>
         /// <param name="count">The count.</param>
+        /// <param name="encoding">The encoding.</param>            
         /// <returns></returns>
-        public static DbaseFileHeader GetHeader(IFeature feature, int count, Encoding encoding = null)
+        public static DbaseFileHeader GetHeader(IFeature feature, int count)
+        {
+            return GetHeader(feature, count, null);
+        }    
+        
+        /// <summary>
+        /// Gets the stub header.
+        /// </summary>
+        /// <param name="feature">The feature.</param>
+        /// <param name="count">The count.</param>
+        /// <param name="encoding">The encoding.</param>            
+        /// <returns></returns>
+        public static DbaseFileHeader GetHeader(IFeature feature, int count, Encoding encoding)
         {
             var attribs = feature.Attributes;
             string[] names = attribs.GetNames();


### PR DESCRIPTION
GetHeader will always result in DefaultEncoding and will not be usable in a ShapefileDataWriter with a different encoding.

It would be better to make GetHeader non-static and make it use the _encoding of the ShapefileDataWriter itself (but that breaks the API...)