### PR TITLE
#27 immediate "lazy" evaluation to avoid dispose issues

### DIFF
--- a/src/NetTopologySuite.IO.ShapeFile/ShapeFile.Extended/Entities/ShapefileFeature.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/ShapeFile.Extended/Entities/ShapefileFeature.cs
@@ -11,19 +11,17 @@ namespace NetTopologySuite.IO.ShapeFile.Extended.Entities
     [Serializable]
     internal class ShapefileFeature : IShapefileFeature, ISerializable
     {
-        private readonly Lazy<Geometry> _lazyGeometry;
-        private readonly Lazy<IAttributesTable> _lazyAttributeTable;
 
         public ShapefileFeature(ShapeReader shapeReader, DbaseReader dbfReader, ShapeLocationInFileInfo shapeLocation, GeometryFactory geoFactory)
         {
             FeatureId = shapeLocation.ShapeIndex;
 
-            // immediate "lazy" evaluation to avoid dispose issues (see #27)
+            // removed "lazy" evaluation to avoid dispose issues (see #27)
             var geom = shapeReader.ReadShapeAtOffset(shapeLocation.OffsetFromStartOfFile, geoFactory);
             var attributes = dbfReader.ReadEntry(shapeLocation.ShapeIndex);
 
-            _lazyGeometry = new Lazy<Geometry>(() => geom);
-            _lazyAttributeTable = new Lazy<IAttributesTable>(() => attributes);
+            Geometry = geom;
+            Attributes = attributes;
         }
 
         private ShapefileFeature(SerializationInfo info, StreamingContext context)
@@ -32,15 +30,15 @@ namespace NetTopologySuite.IO.ShapeFile.Extended.Entities
             var attributes = (IAttributesTable)info.GetValue("Attributes", typeof(IAttributesTable));
 
             FeatureId = info.GetInt64("FeatureId");
-            _lazyGeometry = new Lazy<Geometry>(() => geom);
-            _lazyAttributeTable = new Lazy<IAttributesTable>(() => attributes);
+            Geometry = geom;
+            Attributes = attributes;
         }
 
-        public Geometry Geometry => _lazyGeometry.Value;
+        public Geometry Geometry { get; }
 
         public Envelope BoundingBox => Geometry.EnvelopeInternal;
 
-        public IAttributesTable Attributes => _lazyAttributeTable.Value;
+        public IAttributesTable Attributes { get; }
 
         public long FeatureId { get; }
 

--- a/src/NetTopologySuite.IO.ShapeFile/ShapeFile.Extended/Entities/ShapefileFeature.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/ShapeFile.Extended/Entities/ShapefileFeature.cs
@@ -17,8 +17,13 @@ namespace NetTopologySuite.IO.ShapeFile.Extended.Entities
         public ShapefileFeature(ShapeReader shapeReader, DbaseReader dbfReader, ShapeLocationInFileInfo shapeLocation, GeometryFactory geoFactory)
         {
             FeatureId = shapeLocation.ShapeIndex;
-            _lazyGeometry = new Lazy<Geometry>(() => shapeReader.ReadShapeAtOffset(shapeLocation.OffsetFromStartOfFile, geoFactory), LazyThreadSafetyMode.ExecutionAndPublication);
-            _lazyAttributeTable = new Lazy<IAttributesTable>(() => dbfReader.ReadEntry(shapeLocation.ShapeIndex), LazyThreadSafetyMode.ExecutionAndPublication);
+
+            // immediate "lazy" evaluation to avoid dispose issues (see #27)
+            var geom = shapeReader.ReadShapeAtOffset(shapeLocation.OffsetFromStartOfFile, geoFactory);
+            var attributes = dbfReader.ReadEntry(shapeLocation.ShapeIndex);
+
+            _lazyGeometry = new Lazy<Geometry>(() => geom);
+            _lazyAttributeTable = new Lazy<IAttributesTable>(() => attributes);
         }
 
         private ShapefileFeature(SerializationInfo info, StreamingContext context)

--- a/test/NetTopologySuite.IO.ShapeFile.Test/Issue27Fixture.cs
+++ b/test/NetTopologySuite.IO.ShapeFile.Test/Issue27Fixture.cs
@@ -1,0 +1,40 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using NetTopologySuite.IO.ShapeFile.Extended;
+using NetTopologySuite.IO.ShapeFile.Extended.Entities;
+using System.IO;
+
+namespace NetTopologySuite.IO.ShapeFile.Test
+{
+    [TestFixture]
+    public class Issue27Fixture
+    {
+        /// <summary>
+        /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/27"/>
+        /// </summary>
+        [Test, Category("Issue27")]
+        public void Data_should_be_readable_after_reader_dispose()
+        {
+            var crustal_test = Path.Combine(
+                Path.GetDirectoryName(typeof(Issue27Fixture).Assembly.Location),
+                "TestShapefiles/crustal_test.shp");
+            Assert.True(File.Exists(crustal_test));
+
+            List<IShapefileFeature> data = null;
+            using (var reader = new ShapeDataReader(crustal_test))
+            {
+                var mbr = reader.ShapefileBounds;
+                data = reader.ReadByMBRFilter(mbr).ToList();
+            }
+            Assert.IsNotNull(data);
+            Assert.IsNotEmpty(data);
+
+            foreach (var item in data)
+            {
+                Assert.IsNotNull(item.Geometry);
+                Assert.IsNotNull(item.Attributes["ID_GTR"]);
+            }
+        }
+    }
+}

--- a/test/NetTopologySuite.IO.ShapeFile.Test/ShapeFile.Extended/ShapeDataReaderTests.cs
+++ b/test/NetTopologySuite.IO.ShapeFile.Test/ShapeFile.Extended/ShapeDataReaderTests.cs
@@ -576,8 +576,8 @@ namespace NetTopologySuite.IO.Tests.ShapeFile.Extended
             Assert.IsFalse(results.Any());
         }
 
-        [Test]
-        public void ReadByGeoFilter_ReadDbfDataAfterReaderObjectDisposed_ShouldThrowException()
+        [Test, Category("Issue27")]
+        public void ReadByGeoFilter_ReadDbfDataAfterReaderObjectDisposed_ShouldNotThrowException()
         {
             var boundsWithWholeTriangle = new Envelope(-1.17459, -1.00231, -1.09803, -0.80861);
 
@@ -600,15 +600,12 @@ namespace NetTopologySuite.IO.Tests.ShapeFile.Extended
             // Dispose of the reader object.
             m_shapeDataReader.Dispose();
 
-            // Try reading dbf data.
-            Assert.Catch<InvalidOperationException>(() =>
-            {
-                var table = result.Attributes;
-            });
+            // Try reading data.
+            Assert.IsNotNull(result.Attributes);
         }
 
-        [Test]
-        public void ReadByGeoFilter_ReadShapeDataAfterReaderObjectDisposed_ShouldThrowException()
+        [Test, Category("Issue27")]
+        public void ReadByGeoFilter_ReadShapeDataAfterReaderObjectDisposed_ShouldNotThrowException()
         {
             var boundsWithWholeTriangle = new Envelope(-1.17459, -1.00231, -1.09803, -0.80861);
 
@@ -631,11 +628,8 @@ namespace NetTopologySuite.IO.Tests.ShapeFile.Extended
             // Dispose of the reader object.
             m_shapeDataReader.Dispose();
 
-            // Try reading dbf data.
-            Assert.Catch<InvalidOperationException>(() =>
-            {
-                var table = result.Geometry;
-            });
+            // Try reading data.
+            Assert.IsNotNull(result.Geometry);
         }
 
         [TearDown]


### PR DESCRIPTION
Probably the best code is to remove Lazy objects at all: I don't want to change too much code, but if you wish...   
I needed to "fix" also two tests that explicitely asserts that an exception is thrown if a disposed object was used to read for data.
