### PR TITLE
Feature: ManagedStreamProvider

### DIFF
--- a/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFileHeader.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFileHeader.cs
@@ -13,6 +13,9 @@ namespace NetTopologySuite.IO
     {
         public const int FieldNameMaxLength = 11;
 
+        // Constant for the default header length without field descriptors
+        private const int DefaultHeaderLength = 33;
+
         // Constant for the size of a record
         private const int FileDescriptorSize = 32;
 
@@ -26,7 +29,7 @@ namespace NetTopologySuite.IO
         private int _numRecords;
 
         // Length of the header structure
-        private int _headerLength;
+        private int _headerLength = DefaultHeaderLength;
 
         // Length of the records
         private int _recordLength;
@@ -204,7 +207,7 @@ namespace NetTopologySuite.IO
 
             // set the new fields.
             _fieldDescriptions = tempFieldDescriptors;
-            _headerLength = 33 + 32 * _fieldDescriptions.Length;
+            _headerLength = DefaultHeaderLength + 32 * _fieldDescriptions.Length;
             _numFields = _fieldDescriptions.Length;
             _recordLength = tempLength;
         }
@@ -239,7 +242,7 @@ namespace NetTopologySuite.IO
 
             // set the new fields.
             _fieldDescriptions = tempFieldDescriptors;
-            _headerLength = 33 + 32 * _fieldDescriptions.Length;
+            _headerLength = DefaultHeaderLength + 32 * _fieldDescriptions.Length;
             _numFields = _fieldDescriptions.Length;
             _recordLength = tempLength;
 

--- a/src/NetTopologySuite.IO.ShapeFile/Streams/ExternallyManagedStreamProvider.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/Streams/ExternallyManagedStreamProvider.cs
@@ -8,14 +8,14 @@ namespace NetTopologySuite.IO.Streams
     /// <summary>
     /// A stream provider that provides <see cref="Stream"/>s who are managed by the application.
     /// </summary>
-    public class ManagedStreamProvider : IStreamProvider
+    public class ExternallyManagedStreamProvider : IStreamProvider
     {
         /// <summary>
         /// Creates an instance of this class
         /// </summary>
         /// <param name="kind">The kind of stream</param>
         /// <param name="stream">A <see cref="Stream"/> managed by the application</param>
-        public ManagedStreamProvider(string kind, Stream stream)
+        public ExternallyManagedStreamProvider(string kind, Stream stream)
         {
             Kind = kind;
             Stream = stream;
@@ -48,6 +48,10 @@ namespace NetTopologySuite.IO.Streams
         {
             if (UnderlyingStreamIsReadonly)
                 throw new InvalidOperationException();
+
+            if (truncate) {
+                Stream.SetLength(0);
+            }
 
             return new NonDisposingStream(Stream);
         }

--- a/src/NetTopologySuite.IO.ShapeFile/Streams/ExternallyManagedStreamProvider.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/Streams/ExternallyManagedStreamProvider.cs
@@ -43,13 +43,17 @@ namespace NetTopologySuite.IO.Streams
         /// <remarks>If <see cref="UnderlyingStreamIsReadonly"/> is not <value>true</value>
         /// this method shall fail</remarks>
         /// <returns>An opened stream</returns>
-        /// <exception cref="InvalidOperationException">Thrown if <see cref="UnderlyingStreamIsReadonly"/> is <value>true</value></exception>
+        /// <exception cref="InvalidOperationException">Thrown if <see cref="UnderlyingStreamIsReadonly"/> is <value>true</value> or the underlying stream doesn't support seeking</exception>
         public Stream OpenWrite(bool truncate)
         {
             if (UnderlyingStreamIsReadonly)
                 throw new InvalidOperationException();
 
             if (truncate) {
+                if (!Stream.CanSeek)
+                {
+                    throw new InvalidOperationException("The underlying stream doesn't support seeking! You are unable to truncate the data.");
+                }
                 Stream.SetLength(0);
             }
 

--- a/src/NetTopologySuite.IO.ShapeFile/Streams/ManagedStreamProvider.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/Streams/ManagedStreamProvider.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace NetTopologySuite.IO.Streams
+{
+    /// <summary>
+    /// A stream provider that provides <see cref="Stream"/>s who are managed by the application.
+    /// </summary>
+    public class ManagedStreamProvider : IStreamProvider
+    {
+        /// <summary>
+        /// Creates an instance of this class
+        /// </summary>
+        /// <param name="kind">The kind of stream</param>
+        /// <param name="stream">A <see cref="Stream"/> managed by the application</param>
+        public ManagedStreamProvider(string kind, Stream stream)
+        {
+            Kind = kind;
+            Stream = stream;
+        }
+
+        /// <summary>
+        /// Gets a value indicating that the underlying stream is read-only
+        /// </summary>
+        public bool UnderlyingStreamIsReadonly => !Stream.CanWrite;
+
+        protected Stream Stream { get; private set; }
+
+        /// <summary>
+        /// Function to return a Stream of the bytes
+        /// </summary>
+        /// <returns>An opened stream</returns>
+        public Stream OpenRead()
+        {
+            return Stream;
+        }
+
+        /// <summary>
+        /// Function to open the underlying stream for writing purposes
+        /// </summary>
+        /// <remarks>If <see cref="UnderlyingStreamIsReadonly"/> is not <value>true</value>
+        /// this method shall fail</remarks>
+        /// <returns>An opened stream</returns>
+        /// <exception cref="InvalidOperationException">Thrown if <see cref="UnderlyingStreamIsReadonly"/> is <value>true</value></exception>
+        public Stream OpenWrite(bool truncate)
+        {
+            if (UnderlyingStreamIsReadonly)
+                throw new InvalidOperationException();
+
+            return new NonDisposingStream(Stream);
+        }
+
+        /// <summary>
+        /// Gets a value indicating the kind of stream
+        /// </summary>
+        public string Kind { get; private set; }
+
+
+        private class NonDisposingStream : Stream
+        {
+            public NonDisposingStream(Stream stream)
+            {
+                Stream = stream;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                Stream = null;
+            }
+
+            protected Stream Stream { get; private set; }
+
+            public override bool CanRead => Stream.CanRead;
+
+            public override bool CanSeek => Stream.CanSeek;
+
+            public override bool CanWrite => Stream.CanWrite;
+
+            public override void Flush()
+            {
+                Stream.Flush();
+            }
+
+            public override long Length => Stream.Length;
+
+            public override long Position { get => Stream.Position; set => Stream.Position = value; }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                return Stream.Read(buffer, offset, count);
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                return Stream.Seek(offset, origin);
+            }
+
+            public override void SetLength(long value)
+            {
+                Stream.SetLength(value);
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                Stream.Write(buffer, offset, count);
+            }
+        }
+    }
+}

--- a/test/NetTopologySuite.IO.ShapeFile.Test/Issue60Fixture.cs
+++ b/test/NetTopologySuite.IO.ShapeFile.Test/Issue60Fixture.cs
@@ -1,0 +1,48 @@
+﻿using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+
+namespace NetTopologySuite.IO.ShapeFile.Test
+{
+    [TestFixture]
+    [ShapeFileIssueNumber(60)]
+    public class Issue60Fixture
+    {
+        /// <summary>
+        /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/60"/>
+        /// </summary>
+        /// <remarks>without fix results into System.OverflowException</remarks>
+        [Test]
+        public void Feature_without_fields_should_be_written_correctly()
+        {
+            string test56 = Path.Combine(CommonHelpers.TestShapefilesDirectory, "test60.shp");
+            var factory = new GeometryFactory();
+            var attributes = new AttributesTable();
+            var feature = new Feature(factory.CreatePoint(new Coordinate(1, 2)), attributes);
+
+            var writer = new ShapefileDataWriter(test56);
+            writer.Header = ShapefileDataWriter.GetHeader(feature, 1);
+            writer.Write(new[] { feature });
+
+            using (var reader = new ShapefileDataReader(test56, factory)) {
+
+                if (reader.RecordCount > 0)
+                {
+                    while (reader.Read())
+                    {
+                        Assert.AreEqual(feature.Geometry.AsText(), reader.Geometry.AsText());
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void Header_length_should_always_be_minimal_33()
+        {
+            var header = new DbaseFileHeader();
+            Assert.AreEqual(33, header.HeaderLength);
+        }
+    }
+}

--- a/test/NetTopologySuite.IO.ShapeFile.Test/Streams/ManagedStreamProviderFixture.cs
+++ b/test/NetTopologySuite.IO.ShapeFile.Test/Streams/ManagedStreamProviderFixture.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using NetTopologySuite.IO.Streams;
+using NUnit.Framework;
+
+namespace NetTopologySuite.IO.ShapeFile.Test.Streams
+{
+    [TestFixture]
+    public class ManagedStreamProviderFixture
+    {
+        [TestCase("This is sample text", 1252)]
+        [TestCase("Dies sind deutsche Umlaute: Ää. Öö, Üü, ß", 1252)]
+        [TestCase("Dies sind deutsche Umlaute: Ää. Öö, Üü, ß", 850)]
+        [TestCase("Dies sind deutsche Umlaute: Ää. Öö, Üü, ß", 437)]
+        public void TestConstructorText(string constructorText, int codepage)
+        {
+            var encoding = CodePagesEncodingProvider.Instance.GetEncoding(codepage);
+
+            using (var memoryStream = new MemoryStream())
+            {
+                memoryStream.Write(encoding.GetBytes(constructorText));
+                memoryStream.Position = 0;
+                var bsp = new ManagedStreamProvider("Test", memoryStream);
+
+                Assert.That(bsp.UnderlyingStreamIsReadonly, Is.False);
+
+                using (var streamreader = new StreamReader(bsp.OpenRead(), encoding))
+                {
+                    string streamText = streamreader.ReadToEnd();
+                    Assert.That(streamText, Is.EqualTo(constructorText));
+                }
+            }
+        }
+
+        [TestCase(50, 50, true)]
+        [TestCase(50, 100, true)]
+        [TestCase(50, 50, false)]
+        [TestCase(50, 100, false)]
+        public void TestConstructor(int length, int maxLength, bool @readonly)
+        {
+            using (var memoryStream = new MemoryStream(CreateData(length), 0, length, !@readonly))
+            {
+                memoryStream.Position = 0;
+                var bsp = new ManagedStreamProvider("Test", memoryStream);
+                Assert.That(bsp.UnderlyingStreamIsReadonly, Is.EqualTo(@readonly));
+
+                using (var ms = (MemoryStream)bsp.OpenRead())
+                {
+                    byte[] data = ms.ToArray();
+                    byte[] originalData = memoryStream.ToArray();
+                    Assert.That(data, Is.Not.Null);
+                    Assert.That(data.Length, Is.EqualTo(length));
+                    Assert.That(ms, Is.EqualTo(memoryStream));
+                    for (int i = 0; i < length; i++)
+                        Assert.That(data[i], Is.EqualTo(originalData[i]));
+                }
+
+                try
+                {
+                    using (var ms = (MemoryStream)bsp.OpenWrite(false))
+                    {
+                        var sw = new BinaryWriter(ms);
+                        sw.BaseStream.Position = 50;
+                        for (int i = 0; i < 10; i++)
+                            sw.Write((byte)i);
+                        sw.Flush();
+                        Assert.That(ms.Length, Is.EqualTo(length + 10));
+                        Assert.That(memoryStream.Length, Is.EqualTo(length + 10));
+                        Assert.That(memoryStream.ToArray()[59], Is.EqualTo(9));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (ex is AssertionException)
+                        throw;
+
+                    if (!@readonly)
+                    {
+                        Assert.That(ex, Is.TypeOf(typeof(InvalidOperationException)));
+                        //Assert.That(length, Is.EqualTo(maxLength));
+                    }
+                }
+            }
+        }
+
+        private static byte[] CreateData(int length)
+        {
+            var rnd = new Random();
+
+            byte[] res = new byte[length];
+            for (int i = 0; i < length; i++)
+                res[i] = (byte) rnd.Next(0, 255);
+            return res;
+        }
+    }
+}

--- a/test/NetTopologySuite.IO.ShapeFile.Test/Streams/ManagedStreamProviderFixture.cs
+++ b/test/NetTopologySuite.IO.ShapeFile.Test/Streams/ManagedStreamProviderFixture.cs
@@ -99,14 +99,41 @@ namespace NetTopologySuite.IO.ShapeFile.Test.Streams
             }
         }
 
+        [TestCase]
+        public void TestTruncateNonSeekableStream()
+        {
+            string test = "truncate string";
+
+            using (var memoryStream = new NonSeekableStream())
+            {
+                try
+                {
+                    memoryStream.Write(Encoding.ASCII.GetBytes(test));
+                    memoryStream.Position = 0;
+                    var bsp = new ExternallyManagedStreamProvider("Test", memoryStream);
+                    var stream = bsp.OpenWrite(true);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    Assert.AreEqual(ex.Message, "The underlying stream doesn't support seeking! You are unable to truncate the data.");
+                }
+
+            }
+        }
+
         private static byte[] CreateData(int length)
         {
             var rnd = new Random();
 
             byte[] res = new byte[length];
             for (int i = 0; i < length; i++)
-                res[i] = (byte) rnd.Next(0, 255);
+                res[i] = (byte)rnd.Next(0, 255);
             return res;
+        }
+
+        private class NonSeekableStream : MemoryStream
+        {
+            public override bool CanSeek => false; 
         }
     }
 }

--- a/test/NetTopologySuite.IO.ShapeFile.Test/Streams/ManagedStreamProviderFixture.cs
+++ b/test/NetTopologySuite.IO.ShapeFile.Test/Streams/ManagedStreamProviderFixture.cs
@@ -33,12 +33,11 @@ namespace NetTopologySuite.IO.ShapeFile.Test.Streams
             }
         }
 
-        [TestCase(50, true)]
-        [TestCase(50, true)]
-        [TestCase(50, false)]
-        [TestCase(50, false)]
-        public void TestConstructor(int length, bool @readonly)
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestConstructor(bool @readonly)
         {
+            int length = 50;
             using (var memoryStream = new MemoryStream(CreateData(length), 0, length, !@readonly))
             {
                 memoryStream.Position = 0;

--- a/test/NetTopologySuite.IO.ShapeFile.Test/Streams/ManagedStreamProviderFixture.cs
+++ b/test/NetTopologySuite.IO.ShapeFile.Test/Streams/ManagedStreamProviderFixture.cs
@@ -21,7 +21,7 @@ namespace NetTopologySuite.IO.ShapeFile.Test.Streams
             {
                 memoryStream.Write(encoding.GetBytes(constructorText));
                 memoryStream.Position = 0;
-                var bsp = new ManagedStreamProvider("Test", memoryStream);
+                var bsp = new ExternallyManagedStreamProvider("Test", memoryStream);
 
                 Assert.That(bsp.UnderlyingStreamIsReadonly, Is.False);
 
@@ -33,16 +33,16 @@ namespace NetTopologySuite.IO.ShapeFile.Test.Streams
             }
         }
 
-        [TestCase(50, 50, true)]
-        [TestCase(50, 100, true)]
-        [TestCase(50, 50, false)]
-        [TestCase(50, 100, false)]
-        public void TestConstructor(int length, int maxLength, bool @readonly)
+        [TestCase(50, true)]
+        [TestCase(50, true)]
+        [TestCase(50, false)]
+        [TestCase(50, false)]
+        public void TestConstructor(int length, bool @readonly)
         {
             using (var memoryStream = new MemoryStream(CreateData(length), 0, length, !@readonly))
             {
                 memoryStream.Position = 0;
-                var bsp = new ManagedStreamProvider("Test", memoryStream);
+                var bsp = new ExternallyManagedStreamProvider("Test", memoryStream);
                 Assert.That(bsp.UnderlyingStreamIsReadonly, Is.EqualTo(@readonly));
 
                 using (var ms = (MemoryStream)bsp.OpenRead())
@@ -81,6 +81,21 @@ namespace NetTopologySuite.IO.ShapeFile.Test.Streams
                         //Assert.That(length, Is.EqualTo(maxLength));
                     }
                 }
+            }
+        }
+
+        [TestCase]
+        public void TestTruncate() {
+            string test = "truncate string";
+
+            using (var memoryStream = new MemoryStream())
+            {
+                memoryStream.Write(Encoding.ASCII.GetBytes(test));
+                memoryStream.Position = 0;
+                var bsp = new ExternallyManagedStreamProvider("Test", memoryStream);
+                var stream = bsp.OpenWrite(true);
+
+                Assert.That(stream.Length, Is.EqualTo(0));
             }
         }
 


### PR DESCRIPTION
Added an additional streamProvider called ManagedSteamProvider. The goal of this provider is that the developer can use an own managed stream to which a shape can be written. In the current solution there is no possibility to write to a stream an consume this stream in you application code. This provider solves this issue.