### PR TITLE
Fix/dbase file descriptor #56

### DIFF
--- a/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFieldDescriptor.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFieldDescriptor.cs
@@ -176,7 +176,8 @@ namespace NetTopologySuite.IO
                     case 'N': // numeric
                         if (DecimalCount == 0)
                         {
-                            if (Length < 10)
+                            // Align with the logic when creating a header which specifies a length 10 for an Int32.
+                            if (Length =< 10)
                                 return typeof (int);
                             return typeof (long);
                         }

--- a/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFieldDescriptor.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFieldDescriptor.cs
@@ -177,7 +177,7 @@ namespace NetTopologySuite.IO
                         if (DecimalCount == 0)
                         {
                             // Align with the logic when creating a header which specifies a length 10 for an Int32.
-                            if (Length =< 10)
+                            if (Length <= 10)
                                 return typeof (int);
                             return typeof (long);
                         }

--- a/test/NetTopologySuite.IO.ShapeFile.Test/Issue56Fixture.cs
+++ b/test/NetTopologySuite.IO.ShapeFile.Test/Issue56Fixture.cs
@@ -1,0 +1,45 @@
+﻿using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+
+namespace NetTopologySuite.IO.ShapeFile.Test
+{
+    [TestFixture]
+    [ShapeFileIssueNumber(56)]
+    public class Issue56Fixture
+    {
+        /// <summary>
+        /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/56"/>
+        /// </summary>
+        [Test]
+        public void Data_should_be_readable_after_reader_dispose()
+        {
+            string test56 = Path.Combine(CommonHelpers.TestShapefilesDirectory, "test56.shp");
+            var factory = new GeometryFactory();
+            int intValue = 56;
+            string key = "id";
+            var attributes = new AttributesTable();
+            attributes.Add(key, intValue);
+            var feature = new Feature(factory.CreatePoint(new Coordinate(1, 2)), attributes);
+
+            var writer = new ShapefileDataWriter(test56);
+            writer.Header = ShapefileDataWriter.GetHeader(feature, 1);
+            writer.Write(new[] { feature });
+
+            using (var reader = new ShapefileDataReader(test56, factory)) {
+
+                if (reader.RecordCount > 0)
+                {
+                    while (reader.Read())
+                    {
+                        int index = reader.GetOrdinal(key);
+                        Assert.AreEqual(intValue.GetType(), reader.GetFieldType(index));
+                    }
+                }
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
When creating a header the length of an Int32 is set to 10.

https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/blob/c0819c1cfbf8c52146a0004e0e7b3a2b48044d98/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFieldDescriptor.cs#L176-L184
With the following values:
https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/blob/c0819c1cfbf8c52146a0004e0e7b3a2b48044d98/src/NetTopologySuite.IO.ShapeFile/ShapefileDataWriter.cs#L97-L101