### PR TITLE
Make header length correct without fields

### DIFF
--- a/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFileHeader.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFileHeader.cs
@@ -13,6 +13,9 @@ namespace NetTopologySuite.IO
     {
         public const int FieldNameMaxLength = 11;
 
+        // Constant for the default header length without field descriptors
+        private const int DefaultHeaderLength = 33;
+
         // Constant for the size of a record
         private const int FileDescriptorSize = 32;
 
@@ -26,7 +29,7 @@ namespace NetTopologySuite.IO
         private int _numRecords;
 
         // Length of the header structure
-        private int _headerLength;
+        private int _headerLength = DefaultHeaderLength;
 
         // Length of the records
         private int _recordLength;
@@ -204,7 +207,7 @@ namespace NetTopologySuite.IO
 
             // set the new fields.
             _fieldDescriptions = tempFieldDescriptors;
-            _headerLength = 33 + 32 * _fieldDescriptions.Length;
+            _headerLength = DefaultHeaderLength + 32 * _fieldDescriptions.Length;
             _numFields = _fieldDescriptions.Length;
             _recordLength = tempLength;
         }
@@ -239,7 +242,7 @@ namespace NetTopologySuite.IO
 
             // set the new fields.
             _fieldDescriptions = tempFieldDescriptors;
-            _headerLength = 33 + 32 * _fieldDescriptions.Length;
+            _headerLength = DefaultHeaderLength + 32 * _fieldDescriptions.Length;
             _numFields = _fieldDescriptions.Length;
             _recordLength = tempLength;
 

--- a/test/NetTopologySuite.IO.ShapeFile.Test/Issue60Fixture.cs
+++ b/test/NetTopologySuite.IO.ShapeFile.Test/Issue60Fixture.cs
@@ -1,0 +1,48 @@
+﻿using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+
+namespace NetTopologySuite.IO.ShapeFile.Test
+{
+    [TestFixture]
+    [ShapeFileIssueNumber(60)]
+    public class Issue60Fixture
+    {
+        /// <summary>
+        /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/60"/>
+        /// </summary>
+        /// <remarks>without fix results into System.OverflowException</remarks>
+        [Test]
+        public void Feature_without_fields_should_be_written_correctly()
+        {
+            string test56 = Path.Combine(CommonHelpers.TestShapefilesDirectory, "test60.shp");
+            var factory = new GeometryFactory();
+            var attributes = new AttributesTable();
+            var feature = new Feature(factory.CreatePoint(new Coordinate(1, 2)), attributes);
+
+            var writer = new ShapefileDataWriter(test56);
+            writer.Header = ShapefileDataWriter.GetHeader(feature, 1);
+            writer.Write(new[] { feature });
+
+            using (var reader = new ShapefileDataReader(test56, factory)) {
+
+                if (reader.RecordCount > 0)
+                {
+                    while (reader.Read())
+                    {
+                        Assert.AreEqual(feature.Geometry.AsText(), reader.Geometry.AsText());
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void Header_length_should_always_be_minimal_33()
+        {
+            var header = new DbaseFileHeader();
+            Assert.AreEqual(33, header.HeaderLength);
+        }
+    }
+}


### PR DESCRIPTION
Pushed a possible fix for issue #60. By setting the HeaderLength default to 33, it solves the issue