### PR TITLE
Allow null values to be read.

### DIFF
--- a/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFileReader.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFileReader.cs
@@ -144,6 +144,13 @@ namespace NetTopologySuite.IO
                         {
                             case 'L': // logical data type, one character (T,t,F,f,Y,y,N,n)
                                 char tempChar = (char)_dbfReader.ReadByte();
+
+                                // if value is space convert to null
+                                if (tempChar == ' ') {
+                                    tempObject = null;
+                                    break;
+                                }
+
                                 if ((tempChar == 'T') || (tempChar == 't') || (tempChar == 'Y') || (tempChar == 'y'))
                                     tempObject = true;
                                 else tempObject = false;
@@ -161,6 +168,9 @@ namespace NetTopologySuite.IO
                                 {
                                     byte[] buf = _dbfReader.ReadBytes(tempFieldLength);
                                     tempObject = _header.Encoding.GetString(buf, 0, buf.Length).Trim();
+                                }
+                                if (string.IsNullOrWhiteSpace(tempObject as string)) {
+                                    tempObject = null;
                                 }
                                 break;
 
@@ -216,6 +226,12 @@ namespace NetTopologySuite.IO
                                 {
                                     // if we can't format the number, just save it as a string
                                     tempObject = tempString;
+
+                                    // if value is space convert to null
+                                    if (string.IsNullOrWhiteSpace(tempString))
+                                    {
+                                        tempObject = null;
+                                    }
                                 }
                                 break;
 

--- a/test/NetTopologySuite.IO.ShapeFile.Test/Issue64Fixture.cs
+++ b/test/NetTopologySuite.IO.ShapeFile.Test/Issue64Fixture.cs
@@ -1,0 +1,159 @@
+﻿using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NUnit.Framework;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+namespace NetTopologySuite.IO.ShapeFile.Test
+{
+    [TestFixture]
+    [ShapeFileIssueNumber(64)]
+    public class Issue64Fixture
+    {
+        /// <summary>
+        /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/64"/>
+        /// </summary>
+        [Test]
+        public void Dbase_Read_Null_from_logical()
+        {
+            string test64 = Path.Combine(CommonHelpers.TestShapefilesDirectory, "test64.dbf");
+            var header = new DbaseFileHeader();
+            header.AddColumn("bool", 'L', 1, 0);
+            header.NumRecords = 1;
+
+            object[] values = new[] { (object)null };
+
+            using (var writer = new DbaseFileWriter(test64))
+            {
+                writer.Write(header);
+                writer.Write(values);
+            }
+
+            var reader = new DbaseFileReader(test64);
+
+            reader.GetHeader();
+
+            foreach (ArrayList readValues in reader)
+            {
+                Assert.AreEqual(values[0], readValues[0]);
+            }
+        }
+
+        /// <summary>
+        /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/64"/>
+        /// </summary>
+        [Test]
+        public void Dbase_Read_Null_from_date()
+        {
+            string test64 = Path.Combine(CommonHelpers.TestShapefilesDirectory, "test64.dbf");
+            var header = new DbaseFileHeader();
+            header.AddColumn("date", 'D', 8, 0);
+            header.NumRecords = 1;
+
+            object[] values = new[] { (object)null };
+
+            using (var writer = new DbaseFileWriter(test64))
+            {
+                writer.Write(header);
+                writer.Write(values);
+            }
+
+            var reader = new DbaseFileReader(test64);
+
+            reader.GetHeader();
+
+            foreach (ArrayList readValues in reader)
+            {
+                Assert.AreEqual(values[0], readValues[0]);
+            }
+        }
+
+        /// <summary>
+        /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/64"/>
+        /// </summary>
+        [Test]
+        public void Dbase_Read_Null_from_float()
+        {
+            string test64 = Path.Combine(CommonHelpers.TestShapefilesDirectory, "test64.dbf");
+            var header = new DbaseFileHeader();
+            header.AddColumn("date", 'F', 8, 0);
+            header.NumRecords = 1;
+
+            object[] values = new[] { (object)null };
+
+            using (var writer = new DbaseFileWriter(test64))
+            {
+                writer.Write(header);
+                writer.Write(values);
+            }
+
+            var reader = new DbaseFileReader(test64);
+
+            reader.GetHeader();
+
+            foreach (ArrayList readValues in reader)
+            {
+                Assert.AreEqual(values[0], readValues[0]);
+            }
+        }
+
+        /// <summary>
+        /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/64"/>
+        /// </summary>
+        [Test]
+        public void Dbase_Read_Null_from_Number()
+        {
+            string test64 = Path.Combine(CommonHelpers.TestShapefilesDirectory, "test64.dbf");
+            var header = new DbaseFileHeader();
+            header.AddColumn("date", 'N', 8, 0);
+            header.NumRecords = 1;
+
+            object[] values = new[] { (object)null };
+
+            using (var writer = new DbaseFileWriter(test64))
+            {
+                writer.Write(header);
+                writer.Write(values);
+            }
+
+            var reader = new DbaseFileReader(test64);
+
+            reader.GetHeader();
+
+            foreach (ArrayList readValues in reader)
+            {
+                Assert.AreEqual(values[0], readValues[0]);
+            }
+        }
+
+        /// <summary>
+        /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/64"/>
+        /// </summary>
+        [Test]
+        public void Dbase_Read_Null_from_Char()
+        {
+            string test64 = Path.Combine(CommonHelpers.TestShapefilesDirectory, "test64.dbf");
+            var header = new DbaseFileHeader();
+            header.AddColumn("date", 'C', 8, 0);
+            header.NumRecords = 1;
+
+            object[] values = new[] { (object)null };
+
+            using (var writer = new DbaseFileWriter(test64))
+            {
+                writer.Write(header);
+                writer.Write(values);
+            }
+
+            var reader = new DbaseFileReader(test64);
+
+            reader.GetHeader();
+
+            foreach (ArrayList readValues in reader)
+            {
+                Assert.AreEqual(values[0], readValues[0]);
+            }
+        }
+    }
+}

--- a/test/NetTopologySuite.IO.ShapeFile.Test/Issue64Fixture.cs
+++ b/test/NetTopologySuite.IO.ShapeFile.Test/Issue64Fixture.cs
@@ -1,9 +1,8 @@
-﻿using NetTopologySuite.Features;
-using NetTopologySuite.Geometries;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Collections;
-using System.Collections.Generic;
 using System.IO;
+
+using NetTopologySuite.IO.Streams;
 
 namespace NetTopologySuite.IO.ShapeFile.Test
 {
@@ -14,141 +13,34 @@ namespace NetTopologySuite.IO.ShapeFile.Test
         /// <summary>
         /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/64"/>
         /// </summary>
-        [Test]
-        public void Dbase_Read_Null_from_logical()
+        [TestCase('L', 1)]
+        [TestCase('D', 8)]
+        [TestCase('F', 8)]
+        [TestCase('N', 8)]
+        [TestCase('C', 8)]
+        public void Dbase_Read_Null(char fieldType, int fieldLength)
         {
-            string test64 = Path.Combine(CommonHelpers.TestShapefilesDirectory, "test64.dbf");
+            using var s = new MemoryStream();
+            var provider = new ExternallyManagedStreamProvider(StreamTypes.Data, s);
+            var reg = new ShapefileStreamProviderRegistry(null, provider);
+
             var header = new DbaseFileHeader();
-            header.AddColumn("bool", 'L', 1, 0);
+            header.AddColumn("TestCol", fieldType, fieldLength, 0);
             header.NumRecords = 1;
 
             object[] values = new[] { (object)null };
 
-            using (var writer = new DbaseFileWriter(test64))
+            using (var writer = new DbaseFileWriter(reg))
             {
                 writer.Write(header);
                 writer.Write(values);
             }
 
-            var reader = new DbaseFileReader(test64);
+            s.Position = 0;
+            var reader = new DbaseFileReader(reg);
 
             reader.GetHeader();
-
-            foreach (ArrayList readValues in reader)
-            {
-                Assert.AreEqual(values[0], readValues[0]);
-            }
-        }
-
-        /// <summary>
-        /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/64"/>
-        /// </summary>
-        [Test]
-        public void Dbase_Read_Null_from_date()
-        {
-            string test64 = Path.Combine(CommonHelpers.TestShapefilesDirectory, "test64.dbf");
-            var header = new DbaseFileHeader();
-            header.AddColumn("date", 'D', 8, 0);
-            header.NumRecords = 1;
-
-            object[] values = new[] { (object)null };
-
-            using (var writer = new DbaseFileWriter(test64))
-            {
-                writer.Write(header);
-                writer.Write(values);
-            }
-
-            var reader = new DbaseFileReader(test64);
-
-            reader.GetHeader();
-
-            foreach (ArrayList readValues in reader)
-            {
-                Assert.AreEqual(values[0], readValues[0]);
-            }
-        }
-
-        /// <summary>
-        /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/64"/>
-        /// </summary>
-        [Test]
-        public void Dbase_Read_Null_from_float()
-        {
-            string test64 = Path.Combine(CommonHelpers.TestShapefilesDirectory, "test64.dbf");
-            var header = new DbaseFileHeader();
-            header.AddColumn("date", 'F', 8, 0);
-            header.NumRecords = 1;
-
-            object[] values = new[] { (object)null };
-
-            using (var writer = new DbaseFileWriter(test64))
-            {
-                writer.Write(header);
-                writer.Write(values);
-            }
-
-            var reader = new DbaseFileReader(test64);
-
-            reader.GetHeader();
-
-            foreach (ArrayList readValues in reader)
-            {
-                Assert.AreEqual(values[0], readValues[0]);
-            }
-        }
-
-        /// <summary>
-        /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/64"/>
-        /// </summary>
-        [Test]
-        public void Dbase_Read_Null_from_Number()
-        {
-            string test64 = Path.Combine(CommonHelpers.TestShapefilesDirectory, "test64.dbf");
-            var header = new DbaseFileHeader();
-            header.AddColumn("date", 'N', 8, 0);
-            header.NumRecords = 1;
-
-            object[] values = new[] { (object)null };
-
-            using (var writer = new DbaseFileWriter(test64))
-            {
-                writer.Write(header);
-                writer.Write(values);
-            }
-
-            var reader = new DbaseFileReader(test64);
-
-            reader.GetHeader();
-
-            foreach (ArrayList readValues in reader)
-            {
-                Assert.AreEqual(values[0], readValues[0]);
-            }
-        }
-
-        /// <summary>
-        /// <see href="https://github.com/NetTopologySuite/NetTopologySuite.IO.ShapeFile/issues/64"/>
-        /// </summary>
-        [Test]
-        public void Dbase_Read_Null_from_Char()
-        {
-            string test64 = Path.Combine(CommonHelpers.TestShapefilesDirectory, "test64.dbf");
-            var header = new DbaseFileHeader();
-            header.AddColumn("date", 'C', 8, 0);
-            header.NumRecords = 1;
-
-            object[] values = new[] { (object)null };
-
-            using (var writer = new DbaseFileWriter(test64))
-            {
-                writer.Write(header);
-                writer.Write(values);
-            }
-
-            var reader = new DbaseFileReader(test64);
-
-            reader.GetHeader();
+            s.Position = 0;
 
             foreach (ArrayList readValues in reader)
             {


### PR DESCRIPTION
Pushed a possible fix for issue #64. If only spaces are available on the bytes you read for a value, convert it to a `null` value