### PR TITLE
Fix DbaseFileReader enumerator

### DIFF
--- a/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFileReader.FullFat.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFileReader.FullFat.cs
@@ -17,7 +17,7 @@ namespace NetTopologySuite.IO
             {
                 _parent = parent;
                 var stream = parent._streamProvider.OpenRead();
-                _dbfReader = new BinaryReader(stream, parent._header.Encoding);
+                _dbfReader = new BinaryReader(stream, parent.GetHeader().Encoding);
                 ReadHeader();
             }
 


### PR DESCRIPTION
Fix NullReferenceException while reading DBF file:
```
System.NullReferenceException
  HResult=0x80004003
  Message=Object reference not set to an instance of an object.
  Source=NetTopologySuite.IO.ShapeFile
  StackTrace:
   at NetTopologySuite.IO.DbaseFileReader.DbaseFileEnumerator..ctor(DbaseFileReader parent) in D:\Work.Dev\VS\Coordinatus.NET\NetTopologySuite.IO.ShapeFile\src\NetTopologySuite.IO.ShapeFile\Dbase\DbaseFileReader.FullFat.cs:line 20
```

Code raising exception:
```c#
var dbfReader = new DbaseFileReader(dbfPath, Encoding.UTF8);
foreach (var dbf in dbfReader)
{
    Debug.WriteLine(dbf);
}
```