### PR TITLE
Fixed issue when writting Features with ShapefileDataWriter.

### DIFF
--- a/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFileWriter.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/Dbase/DbaseFileWriter.cs
@@ -105,7 +105,13 @@ namespace NetTopologySuite.IO
 
             //Header should always be written first in the file
             if (_writer.BaseStream.Position != 0)
+            {
+                if (!_writer.BaseStream.CanSeek)
+                {
+                    throw new NotSupportedException("Underlying stream doesn't support seek!");
+                }
                 _writer.Seek(0, SeekOrigin.Begin);
+            }
 
             // actually write the header
             header.WriteHeader(_writer);

--- a/src/NetTopologySuite.IO.ShapeFile/ShapefileDataWriter.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/ShapefileDataWriter.cs
@@ -218,12 +218,12 @@ namespace NetTopologySuite.IO
                         numFeatures++;
                     }
 
+                    // write the end of dbase file marker
+                    _dbaseWriter.WriteEndOfDbf();
                     // set the number of records
                     Header.NumRecords = numFeatures;
                     // Update the header
                     _dbaseWriter.Write(Header);
-                    // write the end of dbase file marker
-                    _dbaseWriter.WriteEndOfDbf();
 
                     void Write(IFeature feature)
                     {

--- a/src/NetTopologySuite.IO.ShapeFile/ShapefileDataWriter.cs
+++ b/src/NetTopologySuite.IO.ShapeFile/ShapefileDataWriter.cs
@@ -203,17 +203,27 @@ namespace NetTopologySuite.IO
                     string[] fieldNames = Array.ConvertAll(Header.Fields, field => field.Name);
                     object[] values = new object[fieldNames.Length];
 
+                    int numFeatures = 0;
                     // first, write the one(s) that we scanned already.
                     foreach (var feature in headFeatures)
                     {
                         Write(feature);
+                        numFeatures++;
                     }
 
                     // now continue through the features we haven't scanned yet.
                     while (featuresEnumerator.MoveNext())
                     {
                         Write(featuresEnumerator.Current);
+                        numFeatures++;
                     }
+
+                    // set the number of records
+                    Header.NumRecords = numFeatures;
+                    // Update the header
+                    _dbaseWriter.Write(Header);
+                    // write the end of dbase file marker
+                    _dbaseWriter.WriteEndOfDbf();
 
                     void Write(IFeature feature)
                     {


### PR DESCRIPTION
When writting Features Using the ShapefileDataWriter, the file is corrupt when using ArcMap of Qgis.

There are 2 reasons for this:
1. No EndOfDbf byte is written to the dbf file
2. The number of records aren't updated in the header.

The PR here fixes both and is inspired by the static WriteFeatures of the ShapefileWriter

@FObermaier  @airbreather I know you stopped the maintenance of this package in favor of the new implementation, but since this is still in development and I really need this fix, I would love to see this in a new Stable release.